### PR TITLE
feat: Option to use local images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Flask Image Rotator
 
-This is a Flask app that serves a list of images and rotates them every `rotation_time` minutes. The list of image URLs is stored in a `config.yml` file, which can be easily edited to add or remove images.
+This is a Flask app that serves a list of images and rotates them every `rotation_time` minutes. The list of images is stored in a `config.yml` file, which can be easily edited to add or remove images.
 
 ### Installation
 
@@ -13,7 +13,7 @@ pip install -r requirements.txt
 
 ### Configuration
 
-The list of image URLs and the rotation time are configured in the `config.yml` file. Here's an example of what the `config.yml` file might look like:
+The list of images are configured in the `config.yml` file. Here's an example of what the `config.yml` file might look like:
 
 ```yaml
 image_urls:
@@ -21,14 +21,25 @@ image_urls:
   - https://example.com/image2.png
   - https://example.com/image3.png
 
-rotation_time: 1
+image_files:
+  - data/image1.png
+  - data/image2.png
 ```
-In this example, the rotation time is set to 1 minutes, and there are three image URLs in the list. You can edit this file to add or remove images, or to adjust the rotation time.
+
+The `config.yml` file also allows you to configure the rotation time, which determines how frequently the images are rotated. Additionally, you have the option to select either URLs or local files as source.
+
+```yaml
+rotation_time: 1
+
+use_urls: false
+```
+
+To start the Flask app, run the following command:
 
 ```shell
 gunicorn app:app -b 0.0.0.0:8000
 ```
-his will start the Flask app and make it available at `http://localhost:8000/rotate_image`. You can then access the app in a web browser. Images will rotate but you have to refresh the page to see the new ones.
+This will start the Flask app and make it available at `http://localhost:8000/rotate_image`. You can then access the app in a web browser. Images will rotate but you have to refresh the page to see the new ones.
 
 ## Docker
 

--- a/app.py
+++ b/app.py
@@ -14,15 +14,27 @@ with open('config.yml', 'r') as file:
 rotation_time = config['rotation_time']
 image_urls = config['image_urls']
 
+image_files = config['image_files']
+use_urls = config['use_urls']
+
 def fetch_image():
-    # Get the current image index based on the current time
-    current_index = int(time.time() / (rotation_time * 60)) % len(image_urls)
+    if use_urls == True:
+        # Get the current image index based on the current time
+        current_index = int(time.time() / (rotation_time * 60)) % len(image_urls)
 
-    # Fetch the image from the current index
-    response = requests.get(image_urls[current_index])
+        # Fetch the image from the current index
+        response = requests.get(image_urls[current_index])
 
-    # Convert the image data to a byte stream
-    image_stream = io.BytesIO(response.content)
+        # Convert the image data to a byte stream
+        image_stream = io.BytesIO(response.content)
+    else:
+        # Get the current image index based on the current time
+        current_index = int(time.time() / (rotation_time * 60)) % len(image_files)
+
+        # Open the image of the current index
+        with open(image_files[current_index], "rb") as image:
+            b = bytearray(image.read())
+            image_stream = io.BytesIO(b)
 
     # Set the response headers to indicate that this is an image file
     headers = {

--- a/config.example.yml
+++ b/config.example.yml
@@ -4,6 +4,14 @@ image_urls:
   - https://example.com/image2.png
   - https://example.com/image3.png
 
+# Images to rotate
+image_files:
+  - data/image1.png
+  - data/image2.png
+  - data/image3.png
+
 # Rotation time in minuts
 rotation_time: 1
 
+# Use the URLs
+use_urls: false


### PR DESCRIPTION
I've added the option to use local images instead of fetching them from URLs. This should be helpful for people who have their own image files and want to use them directly.

To use this new option, users can specify the path to their local image file in `config.yml`.

Let me know if you have any feedback or questions!